### PR TITLE
ConfOptions:

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ provide way to use it in code as cooked objects
 - make default config, file-based config and command line config
 - merge them all in any sequence to produce clear config as result
 - export config into bash environment script or use it in ruby
+- produce more usable config form than ConfSource object (Array, Hash)
 
 ## It canT
 - add options not mentioned in code (defaults)

--- a/confmaker.gemspec
+++ b/confmaker.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'confmaker'
-  s.version     = '0.0.1'
-  s.summary     = "Your utility configuration maker"
+  s.version     = '0.0.2'
+  s.summary     = "Configuration maker for your utility "
   s.description = "Configuration getter, parser and validator"
   s.authors     = ["nothing"]
   s.files       = ["lib/confmaker.rb","lib/confsources.rb","lib/confoptions.rb"]

--- a/example.rb
+++ b/example.rb
@@ -73,11 +73,16 @@ config = ConfMaker::define_options [
 
 #override defaults with command line
 config.merge! ConfSources::CommandLine.new
-#validation - should be called if all merged
+#validation - can be called if all merged
 config.validate!
 #get option with name :names
 p config[:names].get
-#or just raw value
+#get and merge each option into single hash
+config.to_h
+#or just single raw value
 p config[:join_them][:value]
-puts  config.to_s
+#get array of hashed options (contains types, validator, getter and so on)
+config.to_a
+#Human-readable representation
+puts config.to_s
 

--- a/lib/confoptions.rb
+++ b/lib/confoptions.rb
@@ -1,25 +1,37 @@
 module ConfOptions
+    #Most common option. Only custom validator and getter supports
     class Standard < Hash
         def initialize init_hash
             merge! init_hash
         end
+        #return [name, value] pair
         def to_pair
             [self[:name],self[:value]]
         end
+        #parse otion into some (hash most likely) by using getter Proc
         def get
             if self[:getter].is_a? Proc
                 self[:getter].call self
-            else
+            elsif (private_methods + methods).include? :default_getter
                 default_getter
+            else
+                fallback_getter
             end
         end
+        #human readable representation
         def to_s
             get.collect { |k,v|
                 k.to_s.capitalize.gsub('_',' ') + ': ' + v.to_s
             }.join "\n"
         end
+    private
+        #getter in noone defined
+        def fallback_getter
+            [to_pair].to_h
+        end
     end
     class String < Standard
+        #Validate :value by :validator Proc + default validator for String
         def validate! context = ConfSources::Default.new
             self[:validator].call(self,context) if self[:validator].is_a? Proc
             default_validator if self[:check_regexp]
@@ -30,13 +42,15 @@ module ConfOptions
             elsif self[:env_names].is_a? ::Array and self[:check_regexp].is_a? Regexp
                 default_getter
             else
-                [ to_pair ].to_h
+                fallback_getter
             end
         end
     private
+        #split value into matches by using check_regexp and map it into env_names if both defined
         def default_getter
             (self[:env_names].zip (self[:check_regexp].match self[:value]).to_a).to_h
         end
+        #Basic class and check_regexp checks
         def default_validator
             raise RuntimeError, "Option #{self[:name]} become #{self[:value].class} during validation" unless self[:value].is_a? ::String or self[:value].kind_of? Numeric
             raise ArgumentError, "#{self[:desc]} (#{self[:value].to_s}) must satisfy #{self[:check_regexp].to_s}" unless
@@ -47,9 +61,6 @@ module ConfOptions
         def validate! context = ConfSources::Default.new
             default_validator
             self[:validator].call(self,context) if self[:validator].is_a? Proc
-        end
-        def to_s
-            (self[:env_name] ? self[:env_name] : self[:name] ).to_s.capitalize.gsub('_',' ') + ': ' + self[:value].to_s
         end
     private
         def default_getter

--- a/lib/confsources.rb
+++ b/lib/confsources.rb
@@ -41,9 +41,15 @@ module ConfSources
                 el.validate! Clone.new(self)
             }
         end
+        #array of option hashes (including names, desc and so on)
         def to_a
             @options.collect{ |opt| opt.to_h }
         end
+        #hash with parsed values
+        def to_h
+            @options.inject({}){|rez,opt| rez.merge opt.get}
+        end
+        #:name => :value hash
         def to_pairs
             @options.collect{ |opt| opt.to_pair }.to_h
         end


### PR DESCRIPTION
- Default become usable
- to_s code dup removed
- methods commented
More code-usable getters realized for ConfSources
examples updated with to_a/to_h usage
version 0.0.2